### PR TITLE
chore(primitives): BlockID with U64 Alloy Primitive Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "superchain"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "superchain-primitives",
  "superchain-registry",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "superchain-primitives"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -707,12 +707,14 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "serde",
+ "serde_json",
  "serde_repr",
+ "toml",
 ]
 
 [[package]]
 name = "superchain-registry"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy-primitives",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.80"
 authors = ["anton-rs"]
@@ -113,8 +113,8 @@ incremental = false
 
 [workspace.dependencies]
 # Workspace
-superchain-registry = { path = "crates/registry", version = "0.3.2", default-features = false }
-superchain-primitives = { path = "crates/primitives", version = "0.3.2", default-features = false }
+superchain-registry = { path = "crates/registry", version = "0.3.3", default-features = false }
+superchain-primitives = { path = "crates/primitives", version = "0.3.3", default-features = false }
 
 # Alloy
 alloy-sol-types = { version = "0.8.0", default-features = false }
@@ -126,6 +126,7 @@ alloy-eips = { version = "0.3", default-features = false }
 # Serialization
 toml = { version = "0.8.14" }
 serde_repr = "0.1"
+serde_json = "1.0"
 serde = { version = "1.0.203", default-features = false, features = ["derive", "alloc"] }
 
 # Misc

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -21,8 +21,12 @@ anyhow.workspace = true
 # `serde` feature flag dependencies
 serde = { workspace = true, optional = true }
 serde_repr = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+
+[dev-dependencies]
+toml.workspace = true
 
 [features]
 default = ["std", "serde"]
 std = []
-serde = ["dep:serde", "dep:serde_repr", "alloy-eips/serde", "alloy-consensus/serde", "alloy-primitives/serde"]
+serde = ["dep:serde", "dep:serde_repr", "dep:serde_json", "alloy-eips/serde", "alloy-consensus/serde", "alloy-primitives/serde"]

--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -1,24 +1,130 @@
 //! Block Types
 
-use alloy_primitives::B256;
-use core::fmt::Display;
+use alloy_primitives::{B256, U64};
 
 /// Block identifier.
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct BlockID {
     /// Block hash
     pub hash: B256,
     /// Block number
-    pub number: u64,
+    pub number: U64,
 }
 
-impl Display for BlockID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "BlockID {{ hash: {}, number: {} }}",
-            self.hash, self.number
-        )
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for BlockID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut value = serde_json::Value::deserialize(deserializer)?;
+
+        if let Some(obj) = value.as_object_mut() {
+            let value = obj
+                .get("number")
+                .ok_or_else(|| serde::de::Error::custom("Missing key \"number\""))?;
+            if let serde_json::Value::Number(n) = value {
+                let n = n.as_u64().ok_or_else(|| {
+                    serde::de::Error::custom("failed to deserialize number as u64")
+                })?;
+                let n = serde_json::to_string(&U64::from(n)).map_err(|_| {
+                    serde::de::Error::custom(
+                        "failed to serialize U64 to hex string during deserialization",
+                    )
+                })?;
+                obj.insert("number".to_string(), serde_json::Value::String(n));
+            }
+        }
+
+        if let Some(obj) = value.as_object() {
+            let number = obj
+                .get("number")
+                .ok_or_else(|| serde::de::Error::custom("Missing key \"number\""))?;
+            let serde_json::Value::String(s) = number else {
+                return Err(serde::de::Error::custom("invalid type for key \"number\""));
+            };
+            let s = s.replace("\"", "");
+            let number = match s.starts_with("0x") {
+                true => {
+                    let s = s.strip_prefix("0x").ok_or_else(|| {
+                        serde::de::Error::custom("failed to deserialize number string")
+                    })?;
+                    U64::from_str_radix(s, 16).map_err(|_| {
+                        serde::de::Error::custom("failed to deserialize number string")
+                    })?
+                }
+                false => U64::from_str_radix(&s, 10)
+                    .map_err(|_| serde::de::Error::custom("failed to deserialize number string"))?,
+            };
+            let hash = obj
+                .get("hash")
+                .ok_or_else(|| serde::de::Error::custom("Missing key \"hash\""))?;
+            let serde_json::Value::String(s) = hash else {
+                return Err(serde::de::Error::custom("invalid type for key \"hash\""));
+            };
+            use core::str::FromStr;
+            let hash = match s.starts_with("0x") {
+                true => B256::from_str(s)
+                    .map_err(|_| serde::de::Error::custom("failed to deserialize number string"))?,
+                false => B256::from_str(s)
+                    .map_err(|_| serde::de::Error::custom("failed to deserialize number string"))?,
+            };
+            return Ok(BlockID { hash, number });
+        }
+
+        Err(serde::de::Error::custom("failed to deserialized BlockID"))
+    }
+}
+
+impl BlockID {
+    /// Instantiates a new [BlockID].
+    pub const fn new(hash: B256, number: U64) -> BlockID {
+        Self { hash, number }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod tests {
+    use super::*;
+    use alloy_primitives::b256;
+
+    #[test]
+    fn block_id_toml() {
+        let b1 = BlockID::new(
+            b256!("438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"),
+            U64::from(17422590),
+        );
+        let b2 = toml::from_str("hash = \"0x438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108\"\nnumber = 17422590\n").unwrap();
+        assert_eq!(b1, b2);
+    }
+
+    #[test]
+    fn block_id_serde() {
+        let block_id = BlockID {
+            hash: B256::from([1; 32]),
+            number: U64::from(1),
+        };
+
+        let block_id2: BlockID = serde_json::from_str(r#"{"hash":"0x0101010101010101010101010101010101010101010101010101010101010101","number":1}"#).unwrap();
+        assert_eq!(block_id, block_id2);
+    }
+
+    #[test]
+    fn test_block_id_serde_with_hex() {
+        let block_id = BlockID {
+            hash: B256::from([1; 32]),
+            number: U64::from(1),
+        };
+
+        let json = serde_json::to_string(&block_id).unwrap();
+        assert_eq!(
+            json,
+            r#"{"hash":"0x0101010101010101010101010101010101010101010101010101010101010101","number":"0x1"}"#
+        );
+
+        let block_id2: BlockID = serde_json::from_str(&json).unwrap();
+        assert_eq!(block_id, block_id2);
     }
 }

--- a/crates/primitives/src/rollup_config.rs
+++ b/crates/primitives/src/rollup_config.rs
@@ -334,11 +334,11 @@ pub const OP_MAINNET_CONFIG: RollupConfig = RollupConfig {
     genesis: ChainGenesis {
         l1: BlockID {
             hash: b256!("438335a20d98863a4c0c97999eb2481921ccd28553eac6f913af7c12aec04108"),
-            number: 17_422_590_u64,
+            number: uint!(17_422_590_U64),
         },
         l2: BlockID {
             hash: b256!("dbf6a80fef073de06add9b0d14026d6e5a86c85f6d102c36d3d8e9cf89c2afd3"),
-            number: 105_235_063_u64,
+            number: uint!(105_235_063_U64),
         },
         l2_time: 1_686_068_903_u64,
         system_config: Some(SystemConfig {
@@ -381,11 +381,11 @@ pub const OP_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     genesis: ChainGenesis {
         l1: BlockID {
             hash: b256!("48f520cf4ddaf34c8336e6e490632ea3cf1e5e93b0b2bc6e917557e31845371b"),
-            number: 4071408,
+            number: uint!(4071408_U64),
         },
         l2: BlockID {
             hash: b256!("102de6ffb001480cc9b8b548fd05c34cd4f46ae4aa91759393db90ea0409887d"),
-            number: 0,
+            number: uint!(0_U64),
         },
         l2_time: 1691802540,
         system_config: Some(SystemConfig {
@@ -428,11 +428,11 @@ pub const BASE_MAINNET_CONFIG: RollupConfig = RollupConfig {
     genesis: ChainGenesis {
         l1: BlockID {
             hash: b256!("5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771"),
-            number: 17_481_768_u64,
+            number: uint!(17_481_768_U64),
         },
         l2: BlockID {
             hash: b256!("f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"),
-            number: 0_u64,
+            number: uint!(0_U64),
         },
         l2_time: 1686789347_u64,
         system_config: Some(SystemConfig {
@@ -475,11 +475,11 @@ pub const BASE_SEPOLIA_CONFIG: RollupConfig = RollupConfig {
     genesis: ChainGenesis {
         l1: BlockID {
             hash: b256!("cac9a83291d4dec146d6f7f69ab2304f23f5be87b1789119a0c5b1e4482444ed"),
-            number: 4370868,
+            number: uint!(4370868_U64),
         },
         l2: BlockID {
             hash: b256!("0dcc9e089e30b90ddfc55be9a37dd15bc551aeee999d2e2b51414c54eaf934e4"),
-            number: 0,
+            number: uint!(0_U64),
         },
         l2_time: 1695768288,
         system_config: Some(SystemConfig {

--- a/crates/registry/src/superchain.rs
+++ b/crates/registry/src/superchain.rs
@@ -92,11 +92,11 @@ mod tests {
             batch_inbox_addr: address!("ff00000000000000000000000000000000008453"),
             genesis: ChainGenesis {
                 l1: BlockID {
-                    number: 17481768,
+                    number: uint!(17481768_U64),
                     hash: b256!("5c13d307623a926cd31415036c8b7fa14572f9dac64528e857a470511fc30771"),
                 },
                 l2: BlockID {
-                    number: 0,
+                    number: uint!(0_U64),
                     hash: b256!("f712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd"),
                 },
                 l2_time: 1686789347,


### PR DESCRIPTION
### Description

> [!WARNING]
>
> This is heinous, reader beware.

`toml` doesn't support deserializing a `U64` integer type, but `serde_json` does.

This is a custom deserialize implementation so that both hex and integer decodings work.