### PR TITLE
fix: alloy-eips dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,14 +22,14 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-consensus"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7198a527b4c4762cb88d54bcaeb0428f4298b72552c9c8ec4af614b4a4990c59"
+checksum = "4177d135789e282e925092be8939d421b701c6d92c0a16679faa659d9166289d"
 dependencies = [
- "alloy-eips 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-serde",
  "serde",
 ]
 
@@ -57,42 +57,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159eab0e4e15b88571f55673af37314f4b8f17630dc1b393c3d70f2128a1d494"
+checksum = "499ee14d296a133d142efd215eb36bf96124829fe91cf8f5d4e5ccdd381eae00"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-serde",
  "c-kzg",
  "serde",
  "sha2",
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "0.3.0"
-source = "git+https://github.com/alloy-rs/alloy#24e97da7fa86d6cd49b418a1c89702648c36d36b"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde 0.3.0 (git+https://github.com/alloy-rs/alloy)",
- "c-kzg",
- "serde",
-]
-
-[[package]]
 name = "alloy-genesis"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210f4b358d724f85df8adaec753c583defb58169ad3cad3d48c80d1a25a6ff0e"
+checksum = "4b85dfc693e4a1193f0372a8f789df12ab51fcbe7be0733baa04939a86dd813b"
 dependencies = [
  "alloy-primitives",
- "alloy-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "alloy-serde",
  "serde",
 ]
 
@@ -132,24 +118,14 @@ checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd260ede54f0b53761fdd04133acc10ae70427f66a69aa9590529bbd066cd58"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "0.3.0"
-source = "git+https://github.com/alloy-rs/alloy#24e97da7fa86d6cd49b418a1c89702648c36d36b"
+checksum = "ae417978015f573b4a8c02af17f88558fb22e3fccd12e8a910cf6a2ff331cfcb"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -167,7 +143,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -183,7 +159,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -199,7 +175,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
  "syn-solidity",
 ]
 
@@ -351,7 +327,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -432,9 +408,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -624,9 +600,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -660,7 +636,7 @@ checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -683,7 +659,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -725,7 +701,7 @@ name = "superchain-primitives"
 version = "0.3.2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 0.3.0 (git+https://github.com/alloy-rs/alloy)",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-sol-types",
@@ -758,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -776,7 +752,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -888,7 +864,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -908,5 +884,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.77",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,10 +26,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7198a527b4c4762cb88d54bcaeb0428f4298b72552c9c8ec4af614b4a4990c59"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
@@ -65,10 +65,24 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "c-kzg",
  "serde",
  "sha2",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.3.0"
+source = "git+https://github.com/refcell/alloy?branch=rf/fix/alloy-eips#777783a3cca6157e41a72e0d5b668ff28aa36816"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.3.0 (git+https://github.com/refcell/alloy?branch=rf/fix/alloy-eips)",
+ "c-kzg",
+ "serde",
 ]
 
 [[package]]
@@ -78,7 +92,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "210f4b358d724f85df8adaec753c583defb58169ad3cad3d48c80d1a25a6ff0e"
 dependencies = [
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
@@ -126,6 +140,16 @@ name = "alloy-serde"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd260ede54f0b53761fdd04133acc10ae70427f66a69aa9590529bbd066cd58"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.3.0"
+source = "git+https://github.com/refcell/alloy?branch=rf/fix/alloy-eips#777783a3cca6157e41a72e0d5b668ff28aa36816"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -701,7 +725,7 @@ name = "superchain-primitives"
 version = "0.3.2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 0.3.0 (git+https://github.com/refcell/alloy?branch=rf/fix/alloy-eips)",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,13 +74,13 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.3.0"
-source = "git+https://github.com/refcell/alloy?branch=rf/fix/alloy-eips#777783a3cca6157e41a72e0d5b668ff28aa36816"
+source = "git+https://github.com/alloy-rs/alloy#24e97da7fa86d6cd49b418a1c89702648c36d36b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 0.3.0 (git+https://github.com/refcell/alloy?branch=rf/fix/alloy-eips)",
+ "alloy-serde 0.3.0 (git+https://github.com/alloy-rs/alloy)",
  "c-kzg",
  "serde",
 ]
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.3.0"
-source = "git+https://github.com/refcell/alloy?branch=rf/fix/alloy-eips#777783a3cca6157e41a72e0d5b668ff28aa36816"
+source = "git+https://github.com/alloy-rs/alloy#24e97da7fa86d6cd49b418a1c89702648c36d36b"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -725,7 +725,7 @@ name = "superchain-primitives"
 version = "0.3.2"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 0.3.0 (git+https://github.com/refcell/alloy?branch=rf/fix/alloy-eips)",
+ "alloy-eips 0.3.0 (git+https://github.com/alloy-rs/alloy)",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ alloy-sol-types = { version = "0.8.0", default-features = false }
 alloy-primitives = { version = "0.8.0", default-features = false }
 alloy-genesis = { version = "0.3", default-features = false }
 alloy-consensus = { version = "0.3", default-features = false }
-alloy-eips = { version = "0.3", default-features = false }
+alloy-eips = { git = "https://github.com/refcell/alloy", branch = "rf/fix/alloy-eips", default-features = false }
 
 # Serialization
 toml = { version = "0.8.14" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ alloy-sol-types = { version = "0.8.0", default-features = false }
 alloy-primitives = { version = "0.8.0", default-features = false }
 alloy-genesis = { version = "0.3", default-features = false }
 alloy-consensus = { version = "0.3", default-features = false }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false }
+alloy-eips = { version = "0.3", default-features = false }
 
 # Serialization
 toml = { version = "0.8.14" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ alloy-sol-types = { version = "0.8.0", default-features = false }
 alloy-primitives = { version = "0.8.0", default-features = false }
 alloy-genesis = { version = "0.3", default-features = false }
 alloy-consensus = { version = "0.3", default-features = false }
-alloy-eips = { git = "https://github.com/refcell/alloy", branch = "rf/fix/alloy-eips", default-features = false }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", default-features = false }
 
 # Serialization
 toml = { version = "0.8.14" }


### PR DESCRIPTION
### Description

> [!WARNING]
>
> Do not merge - use a published version once https://github.com/alloy-rs/alloy/pull/1222 is merged.

Updates `alloy-eips` so it doesn't break `no_std` compatibility.