### PR TITLE
feat(primitives): Block Arbitrary Impl

### DIFF
--- a/crates/primitives/src/block.rs
+++ b/crates/primitives/src/block.rs
@@ -7,6 +7,7 @@ use core::fmt::Display;
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "PascalCase"))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct BlockID {
     /// Block hash
     pub hash: B256,
@@ -21,5 +22,20 @@ impl Display for BlockID {
             "BlockID {{ hash: {}, number: {} }}",
             self.hash, self.number
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_block_id_display() {
+        let block_id = BlockID {
+            hash: B256::from([0; 32]),
+            number: 0,
+        };
+        let expected = "BlockID { hash: 0x0000000000000000000000000000000000000000000000000000000000000000, number: 0 }";
+        assert_eq!(block_id.to_string(), expected);
     }
 }


### PR DESCRIPTION
### Description

Implements `Arbitrary` for the `BlockID` type.