### PR TITLE
chore: Alloy Primitive Map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,12 +15,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
-
-[[package]]
 name = "alloy-consensus"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,7 +382,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
  "serde",
 ]
 
@@ -718,7 +711,6 @@ version = "0.6.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "hashbrown",
  "lazy_static",
  "op-alloy-genesis",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,11 @@ incremental = false
 
 [dependencies]
 # Alloy
-alloy-primitives = { version = "0.8", default-features = false }
+alloy-primitives = { version = "0.8", default-features = false, features = ["map"] }
 op-alloy-genesis = { version = "0.3", default-features = false, features = ["serde"] }
 
 # Misc
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-hashbrown = { version = "0.14.3", features = ["serde"] }
 
 # Serialization
 serde = { version = "1.0.203", default-features = false, features = ["derive", "alloc"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,7 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
-pub use hashbrown::HashMap;
-
+pub use alloy_primitives::map::HashMap;
 pub use op_alloy_genesis::{ChainConfig, RollupConfig};
 
 pub mod chain_list;
@@ -28,7 +26,7 @@ lazy_static::lazy_static! {
     static ref _INIT: Registry = Registry::from_chain_list();
 
     /// Chain configurations exported from the registry
-    pub static ref CHAINS: Vec<Chain> = _INIT.chains.clone();
+    pub static ref CHAINS: alloc::vec::Vec<Chain> = _INIT.chains.clone();
 
     /// OP Chain configurations exported from the registry
     pub static ref OPCHAINS: HashMap<u64, ChainConfig> = _INIT.op_chains.clone();

--- a/src/superchain.rs
+++ b/src/superchain.rs
@@ -2,8 +2,7 @@
 
 use super::Chain;
 use alloc::{string::String, vec::Vec};
-use alloy_primitives::Address;
-use hashbrown::HashMap;
+use alloy_primitives::{map::HashMap, Address};
 use op_alloy_genesis::{chain::HardForkConfiguration, ChainConfig, RollupConfig};
 
 /// A superchain configuration.


### PR DESCRIPTION
### Description

Removes the `hashbrown` dependency, using the [recently introduced `map` primitive](https://github.com/alloy-rs/core/pull/743) in [`alloy-primitives`](https://github.com/alloy-rs/core/tree/main/crates/primitives).