### PR TITLE
chore: use l2 block rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,6 +2817,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-transport-http",
  "async-trait",
+ "hilo-providers-alloy",
  "http-body-util",
  "kona-driver",
  "op-alloy-genesis",

--- a/crates/driver/src/driver.rs
+++ b/crates/driver/src/driver.rs
@@ -80,6 +80,7 @@ where
         let pipeline = self.init_pipeline(cursor.clone()).await?;
         let exec = EngineController::new(
             self.cfg.l2_engine_url.clone(),
+            self.cfg.l2_rpc_url.clone(),
             self.cfg.jwt_secret,
             cursor.origin(),
             cursor.l2_safe_head().block_info.into(),

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+# Hilo
+hilo-providers-alloy.workspace = true
+
 # Kona
 kona-driver.workspace = true
 

--- a/crates/engine/src/traits.rs
+++ b/crates/engine/src/traits.rs
@@ -38,7 +38,7 @@ pub trait Engine {
 
     /// Returns the [L2BlockInfo] for the given label.
     async fn l2_block_ref_by_label(
-        &self,
+        &mut self,
         label: BlockNumberOrTag,
     ) -> Result<L2BlockInfo, Self::Error>;
 }


### PR DESCRIPTION
### Description

Use the l2 rpc url in the engine client to fetch the l2 block ref.